### PR TITLE
Actually include the code when installing the module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,8 @@ classifiers =
 
 
 [options]
+packages =
+  synapse_user_restrictions
 python_requires = >= 3.7
 
 


### PR DESCRIPTION
This was added to the cookiecutter template by https://github.com/matrix-org/synapse-module-cookiecutter-template/pull/19, which this module predates.

Fixes #5 